### PR TITLE
Allow override of the StanzaProcessor

### DIFF
--- a/server/core/src/main/java/org/apache/vysper/xmpp/server/DefaultServerRuntimeContext.java
+++ b/server/core/src/main/java/org/apache/vysper/xmpp/server/DefaultServerRuntimeContext.java
@@ -184,6 +184,10 @@ public class DefaultServerRuntimeContext implements ServerRuntimeContext, Module
     public StanzaProcessor getStanzaProcessor() {
         return stanzaProcessor;
     }
+    
+    public void setStanzaProcessor(StanzaProcessor stanzaProcessor){
+        this.stanzaProcessor = stanzaProcessor;
+    }
 
     public StanzaRelay getStanzaRelay() {
         return stanzaRelay;

--- a/server/core/src/main/java/org/apache/vysper/xmpp/server/XMPPServer.java
+++ b/server/core/src/main/java/org/apache/vysper/xmpp/server/XMPPServer.java
@@ -46,8 +46,11 @@ import org.apache.vysper.xmpp.modules.extension.xep0160_offline_storage.OfflineS
 import org.apache.vysper.xmpp.modules.roster.RosterModule;
 import org.apache.vysper.xmpp.modules.servicediscovery.ServiceDiscoveryModule;
 import org.apache.vysper.xmpp.protocol.HandlerDictionary;
+import org.apache.vysper.xmpp.protocol.StanzaProcessor;
 import org.apache.vysper.xmpp.state.resourcebinding.DefaultResourceRegistry;
 import org.apache.vysper.xmpp.state.resourcebinding.ResourceRegistry;
+
+import static java.util.Optional.ofNullable;
 
 /**
  * this class is able to boot a standalone XMPP server.
@@ -73,7 +76,9 @@ public class XMPPServer {
     private StorageProviderRegistry storageProviderRegistry;
     
     private StanzaRelayBroker stanzaRelayBroker;
-
+    
+    private StanzaProcessor stanzaProcessor;
+    
     private InputStream tlsCertificate;
 
     private String tlsCertificatePassword;
@@ -116,6 +121,10 @@ public class XMPPServer {
 
     public void setStorageProviderRegistry(StorageProviderRegistry storageProviderRegistry) {
         this.storageProviderRegistry = storageProviderRegistry;
+    }
+
+    public void setStanzaProcessor(StanzaProcessor stanzaProcessor) {
+        this.stanzaProcessor = stanzaProcessor;
     }
 
     public void setTLSCertificateInfo(File certificate, String password) throws FileNotFoundException {
@@ -191,6 +200,7 @@ public class XMPPServer {
                 dictionaries, resourceRegistry);
         serverRuntimeContext.setStorageProviderRegistry(storageProviderRegistry);
         serverRuntimeContext.setTlsContextFactory(tlsContextFactory);
+        ofNullable(stanzaProcessor).ifPresent(serverRuntimeContext::setStanzaProcessor);
 
         for(Module module : initialModules) {
             serverRuntimeContext.addModule(module);

--- a/server/core/src/test/java/org/apache/vysper/xmpp/server/XMPPServerTestCase.java
+++ b/server/core/src/test/java/org/apache/vysper/xmpp/server/XMPPServerTestCase.java
@@ -1,6 +1,14 @@
 package org.apache.vysper.xmpp.server;
 
 import junit.framework.TestCase;
+import org.apache.vysper.storage.inmemory.MemoryStorageProviderRegistry;
+import org.apache.vysper.xmpp.protocol.SessionStateHolder;
+import org.apache.vysper.xmpp.protocol.StanzaProcessor;
+import org.apache.vysper.xmpp.stanza.Stanza;
+
+import java.io.InputStream;
+
+import static org.mockito.Mockito.mock;
 
 /**
  */
@@ -21,4 +29,28 @@ public class XMPPServerTestCase extends TestCase {
             // success, fail through
         }
     }
+    
+    public void testNominalPath() throws Exception {
+        XMPPServer tested = new XMPPServer("foo.com");
+        tested.setStorageProviderRegistry(new MemoryStorageProviderRegistry());
+        tested.setTLSCertificateInfo((InputStream) null, "");
+        tested.addEndpoint(mock(Endpoint.class));
+
+        tested.start();
+    }
+    
+    public void testStanzaProcessorOverride() throws Exception {
+        XMPPServer tested = new XMPPServer("foo.com");
+        StanzaProcessor stanzaProcessor = mock(StanzaProcessor.class);
+        tested.setStorageProviderRegistry(new MemoryStorageProviderRegistry());
+        tested.setTLSCertificateInfo((InputStream) null, "");
+        tested.addEndpoint(mock(Endpoint.class));
+        
+        tested.setStanzaProcessor(stanzaProcessor);
+        
+        tested.start();
+        
+        assertEquals(stanzaProcessor, tested.getServerRuntimeContext().getStanzaProcessor());
+    }
+    
 }


### PR DESCRIPTION
In our vysper implementation, we need to manage JPA transactions and Spring security.
Those are transversal feature relying on ThreadLocal.

In order to be able to bind a database transaction and security context to one Stanza processing, I found that the easiest way would be to proxy the StanzaProcessor.

The proposed change allows to override the default StanzaProcessor.