### PR TITLE
StateAwareProtocolWorker logic prevents StanzaHandler proxying

### DIFF
--- a/server/core/src/main/java/org/apache/vysper/xmpp/protocol/ProtocolWorker.java
+++ b/server/core/src/main/java/org/apache/vysper/xmpp/protocol/ProtocolWorker.java
@@ -108,7 +108,7 @@ public class ProtocolWorker implements StanzaProcessor {
         if (sessionStateHolder.getState() != SessionState.AUTHENTICATED) {
             // is not authenticated...
             if (XMPPCoreStanza.getWrapper(stanza) != null
-                    && !(stanzaHandler instanceof InBandRegistrationHandler)) {
+                    && !(InBandRegistrationHandler.class.isAssignableFrom(stanzaHandler.unwrapType()))) {
                 // ... and is a IQ/PRESENCE/MESSAGE stanza!
                 responseWriter.handleNotAuthorized(sessionContext, stanza);
                 return;

--- a/server/core/src/main/java/org/apache/vysper/xmpp/protocol/StanzaHandler.java
+++ b/server/core/src/main/java/org/apache/vysper/xmpp/protocol/StanzaHandler.java
@@ -39,6 +39,17 @@ public interface StanzaHandler {
     public String getName();
 
     /**
+     * Allows to check the type of the handler by maintaining compatibility with
+     * delegating handlers. Delegating handlers are expected to delegate this call
+     * to their delegates.
+     * 
+     * @return The type wrapped by this handler
+     */
+    default Class<?> unwrapType() {
+        return getClass();
+    }
+
+    /**
      * verifies if the stanza is processed by this handler
      * @param stanza
      * @return true, if it is processed, false otherwise

--- a/server/core/src/main/java/org/apache/vysper/xmpp/protocol/worker/AuthenticatedProtocolWorker.java
+++ b/server/core/src/main/java/org/apache/vysper/xmpp/protocol/worker/AuthenticatedProtocolWorker.java
@@ -36,7 +36,7 @@ public class AuthenticatedProtocolWorker extends AbstractStateAwareProtocolWorke
     @Override
     protected boolean checkState(SessionContext sessionContext, SessionStateHolder sessionStateHolder, Stanza stanza,
             StanzaHandler stanzaHandler) {
-        if (stanzaHandler instanceof StreamStartHandler)
+        if (StreamStartHandler.class.isAssignableFrom(stanzaHandler.unwrapType()))
             return true;
         if (stanzaHandler.verify(stanza))
             return true;

--- a/server/core/src/main/java/org/apache/vysper/xmpp/protocol/worker/EncryptedProtocolWorker.java
+++ b/server/core/src/main/java/org/apache/vysper/xmpp/protocol/worker/EncryptedProtocolWorker.java
@@ -47,17 +47,18 @@ public class EncryptedProtocolWorker extends AbstractStateAwareProtocolWorker {
     protected boolean checkState(SessionContext sessionContext, SessionStateHolder sessionStateHolder, Stanza stanza,
             StanzaHandler stanzaHandler) {
 
-        if (stanzaHandler instanceof StreamStartHandler) {
+        Class<?> handlerUnwrappedType = stanzaHandler.unwrapType();
+        if (StreamStartHandler.class.isAssignableFrom(handlerUnwrappedType)) {
             return true;
-        } else if (stanzaHandler instanceof AbstractSASLHandler) {
+        } else if (AbstractSASLHandler.class.isAssignableFrom(handlerUnwrappedType)) {
             return true;
-        } else if (stanzaHandler instanceof XMLPrologHandler) {
-            return true; // PSI client sends that. 
-        } else if (stanzaHandler instanceof InBandRegistrationHandler) {
+        } else if (XMLPrologHandler.class.isAssignableFrom(handlerUnwrappedType)) {
+            return true; // PSI client sends that.
+        } else if (InBandRegistrationHandler.class.isAssignableFrom(handlerUnwrappedType)) {
             return true;
-        } else if (sessionContext.isServerToServer() && stanzaHandler instanceof DbResultHandler) {
+        } else if (sessionContext.isServerToServer() && DbResultHandler.class.isAssignableFrom(handlerUnwrappedType)) {
             return true;
-        } else if (sessionContext.isServerToServer() && stanzaHandler instanceof DbVerifyHandler) {
+        } else if (sessionContext.isServerToServer() && DbVerifyHandler.class.isAssignableFrom(handlerUnwrappedType)) {
             return true;
         }
         ResponseWriter.writeUnsupportedStanzaError(sessionContext);

--- a/server/core/src/main/java/org/apache/vysper/xmpp/protocol/worker/InitiatedProtocolWorker.java
+++ b/server/core/src/main/java/org/apache/vysper/xmpp/protocol/worker/InitiatedProtocolWorker.java
@@ -42,9 +42,10 @@ public class InitiatedProtocolWorker extends AbstractStateAwareProtocolWorker {
     @Override
     protected boolean checkState(SessionContext sessionContext, SessionStateHolder sessionStateHolder, Stanza stanza,
             StanzaHandler stanzaHandler) {
-        if (stanzaHandler instanceof XMLPrologHandler)
+        Class<?> handlerUnwrappedType = stanzaHandler.unwrapType();
+        if (XMLPrologHandler.class.isAssignableFrom(handlerUnwrappedType))
             return true;
-        if (stanzaHandler instanceof StreamStartHandler)
+        if (StreamStartHandler.class.isAssignableFrom(handlerUnwrappedType))
             return true;
         ResponseWriter.writeUnsupportedStanzaError(sessionContext);
         return false;

--- a/server/core/src/main/java/org/apache/vysper/xmpp/protocol/worker/StartedProtocolWorker.java
+++ b/server/core/src/main/java/org/apache/vysper/xmpp/protocol/worker/StartedProtocolWorker.java
@@ -45,14 +45,15 @@ public class StartedProtocolWorker extends AbstractStateAwareProtocolWorker {
     protected boolean checkState(SessionContext sessionContext, SessionStateHolder sessionStateHolder, Stanza stanza,
             StanzaHandler stanzaHandler) {
 
-        if (stanzaHandler instanceof StartTLSHandler) {
+        Class<?> handlerUnwrappedType = stanzaHandler.unwrapType();
+        if (StartTLSHandler.class.isAssignableFrom(handlerUnwrappedType)) {
             return true;
-        } else if (stanzaHandler instanceof AbstractSASLHandler && 
-            !sessionContext.getServerRuntimeContext().getServerFeatures().isStartTLSRequired()) {
+        } else if (AbstractSASLHandler.class.isAssignableFrom(handlerUnwrappedType)
+                && !sessionContext.getServerRuntimeContext().getServerFeatures().isStartTLSRequired()) {
             return true;
-        } else if (sessionContext.isServerToServer() && stanzaHandler instanceof DbVerifyHandler) {
+        } else if (sessionContext.isServerToServer() && DbVerifyHandler.class.isAssignableFrom(handlerUnwrappedType)) {
             return true;
-        } else if (sessionContext.isServerToServer() && stanzaHandler instanceof DbResultHandler) {
+        } else if (sessionContext.isServerToServer() && DbResultHandler.class.isAssignableFrom(handlerUnwrappedType)) {
             return true;
         }
         ResponseWriter.writeUnsupportedStanzaError(sessionContext);


### PR DESCRIPTION
This is the sequel of https://github.com/apache/mina-vysper/pull/7.

Proxyed core *StanzaHandler* like *StartTLSHandler* are ignored by almost all StateWareProtocolWorker. This is caused by the fact that these workers perform instanceof checks on the StanzaHandler instances.

To fix that, a new method `Class<?> unwrapType()` is added to StanzaHandler interface. This method returns the instance class by default. Delegating stanza handlers will be able to override it to return their delegate classes.