### PR TITLE
Fix the default XML lang tag of `DefaultServerRuntimeContext`

### DIFF
--- a/server/core/src/main/java/org/apache/vysper/xmpp/server/DefaultServerRuntimeContext.java
+++ b/server/core/src/main/java/org/apache/vysper/xmpp/server/DefaultServerRuntimeContext.java
@@ -206,7 +206,7 @@ public class DefaultServerRuntimeContext implements InternalServerRuntimeContext
 
     @Override
     public String getDefaultXMLLang() {
-        return "en_US"; // TODO must be configurable as of RFC3920
+        return "en"; // TODO must be configurable as of RFC3920
     }
 
     public StanzaRelay getStanzaRelay() {


### PR DESCRIPTION
According to [**RFC 6120**](https://xmpp.org/rfcs/rfc6120.html#streams-attr-xmllang) the `xml:lang` must conform to the language identifier format defined in [**BCP 47, RFC 5646**](https://tools.ietf.org/html/rfc5646).

This PR fixes this issue by changing the previously set value `en_US` to `en`. The country code is omitted from this PE to prevent future possible issue. The correct format of *US English* would be`en-US`.

> Some servers will refuse to communicate with `Apache Mina Vysper` if the language tag is not correct.