### PR TITLE
doap.xml: add supported platforms and server category

### DIFF
--- a/doap.xml
+++ b/doap.xml
@@ -12,7 +12,13 @@
         <license rdf:resource='https://github.com/apache/mina-vysper/blob/master/LICENSE.txt'/>
         <language>en</language>
         <programming-language>Java</programming-language>
+        <os>Linux</os>
+        <os>Windows</os>
+        <os>MacOS</os>
+        <category rdf:resource='https://linkmauve.fr/ns/xmpp-doap#category-xmpp'/>
+        <category rdf:resource='https://linkmauve.fr/ns/xmpp-doap#category-jabber'/>
         <category rdf:resource='https://linkmauve.fr/ns/xmpp-doap#category-library'/>
+        <category rdf:resource='https://linkmauve.fr/ns/xmpp-doap#category-server'/>
         <repository>
             <GitRepository>
                 <browse rdf:resource='https://github.com/apache/mina-vysper'/>


### PR DESCRIPTION
I added the new doap.xml from #28 to the XMPP.org directory https://github.com/xsf/xmpp.org/pull/1605
It needs to list of supported platform or OS and also it needs for a "server" category in addition to the "library".